### PR TITLE
Added password fallback and error code response

### DIFF
--- a/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
+++ b/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
@@ -187,15 +187,12 @@ public class NativeBiometric extends Plugin {
                         case "success":
                             call.resolve();
                             break;
+                        case "failed":
+                            call.reject("Verification failed", "10");
+                            break;
                         default:
-                            call.reject("Failed to authenticate");
+                            call.reject("Verification error", "0");
                             break;
-                        /*case "failed":
-                            call.reject("Failed to authenticate");
-                            break;
-                        case "error":
-                            call.error("");
-                            break;*/
                     }
                 }
             }

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,20 @@ BiometricOptions
 | description?        |                                | string | Description for the Android prompt                                                                        |
 | negativeButtonText? | "Cancel"                       | string | Text for the negative button displayed on Android                                                         |
 
+VerifyIdentityErrors
+
+| code | Description                     |
+| ---- | ------------------------------- |
+| "0"  | Biometrics error or unavailable |
+| "10" | authenticationFailed            |
+| "11" | appCancel                       |
+| "12" | invalidContext                  |
+| "13" | notInteractive                  |
+| "14" | passcodeNotSet                  |
+| "15" | systemCancel                    |
+| "16" | userCancel                      |
+| "17" | userFallback                    |
+
 SetCredentialOptions
 
 | Properties | Default | Type   | Description                                                                                                                                                             |


### PR DESCRIPTION
Currently on iOS when a user's biometrics fail the option to enter password or passcode is presented, however selecting this option just dismisses the prompt and returns as failed.

Changing the policy from deviceOwnerAuthenticationWithBiometrics to deviceOwnerAuthentication allows the user to fallback to a passcode or password.

This issue has been previously raised here: #2 

I also added error code messaging indicating the reason for failure should developers want to handle the response differently.

Resolves #2 