### PR TITLE
Set minimum iOS deployment target to 12.0 to match Capacitor 3

### DIFF
--- a/CapacitorNativeBiometric.podspec
+++ b/CapacitorNativeBiometric.podspec
@@ -8,6 +8,6 @@
     s.author = 'Jose Martinez'
     s.source = { :git => 'https://github.com/epicshaggy/capacitor-native-biometric', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '11.0'
+    s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
   end


### PR DESCRIPTION
Cap v3 requires iOS 12 as a minimum and will not allow this plugin to compile in it's current state due to this.

Closes https://github.com/epicshaggy/capacitor-native-biometric/issues/11