### PR TITLE
Remove label 'defaultValue' for Swift 5 compat

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -31,7 +31,7 @@ public class NativeBiometric: CAPPlugin {
         
         obj["isAvailable"] = false
         
-        let useFallback = call.getBool("useFallback", defaultValue: false)
+        let useFallback = call.getBool("useFallback", false)
         let policy = useFallback ? LAPolicy.deviceOwnerAuthentication : LAPolicy.deviceOwnerAuthenticationWithBiometrics
         if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error){
             obj["isAvailable"] = true
@@ -53,7 +53,7 @@ public class NativeBiometric: CAPPlugin {
         let context = LAContext()
         var canEvaluateError: NSError?
         
-        let useFallback = call.getBool("useFallback", defaultValue: false)
+        let useFallback = call.getBool("useFallback", false)
 
         let policy = useFallback ? LAPolicy.deviceOwnerAuthentication : LAPolicy.deviceOwnerAuthenticationWithBiometrics
         


### PR DESCRIPTION
This PR **only** removes the `defaultValue` label in the `getBool` call to make it compile with Xcode 13.3+
