### PR TITLE
Include logic of hide iOS fallback option; Return Android errorCode when verifyResult;

### DIFF
--- a/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
+++ b/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
@@ -220,7 +220,7 @@ public class NativeBiometric extends Plugin {
                         call.reject(data.getStringExtra("errorDetails"), data.getStringExtra("errorCode"));
                         break;
                     default:
-                        call.reject("Verification error: " + data.getStringExtra("result"));
+                        call.reject("Verification error: " + data.getStringExtra("result"), data.getStringExtra("errorCode"));
                         break;
                 }
             }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -78,6 +78,8 @@ public class NativeBiometric: CAPPlugin {
         var canEvaluateError: NSError?
 
         let useFallback = call.getBool("useFallback", false)
+        context.localizedFallbackTitle = useFallback ? nil : ""
+        
         let policy = useFallback ? LAPolicy.deviceOwnerAuthentication : LAPolicy.deviceOwnerAuthenticationWithBiometrics
         
         if context.canEvaluatePolicy(policy, error: &canEvaluateError){


### PR DESCRIPTION
1. Hide the iOS fallback option when "useFallback" is false
- https://developer.apple.com/documentation/localauthentication/lacontext/1514183-localizedfallbacktitle


2. Return Android errorCode when "default" case in verifyResult() function
- To allow identify other errors, e.g. Attempt exceeded, Permanent locked out.