### PR TITLE
remove (Android > verifyIdentity): bridge.saveCall method

### DIFF
--- a/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
+++ b/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
@@ -151,7 +151,6 @@ public class NativeBiometric extends Plugin {
 
             intent.putExtra("useFallback", useFallback);
 
-            bridge.saveCall(call);
             startActivityForResult(call, intent, "verifyResult");
     }
 


### PR DESCRIPTION
The bridge.saveCall method seems to be redundant. This is my understanding based on Capacitor docs which can very much be incorrect.

* in [this example](https://capacitorjs.com/docs/plugins/ios#requestpermissions) it says `If the framework uses a delegate (or callback) API, completing the operation means that the original call will need to be saved and then retrieved once the callback has been invoked.`. This implies that the saved call needs to be accessed at "another place". In Capacitor's example you can see the use of this in the `checkPermissions` method which uses `call`. This isn't the case in this package since the `call` gets passed around through the `startActivityForResult` method
* there's also a similar sentence in [the Android side of things](https://capacitorjs.com/docs/plugins/android#persisting-a-plugin-call). it says `But there are situations where you will need to keep the plugin call available so it can be accessed later` from which "so it can be accessed later" jumps out for me
* lastly, in the docs on [saving the call for single completion](https://capacitorjs.com/docs/v3/core-apis/saving-calls#saving-a-call-for-a-single-completion) I'd point out two things: it says its **possible** to use bridge.saveCall, but not **required**. And that `releaseCall` should be used after `saveCall`

My main concern is not releasing the call after saving since I'm unsure if that can cause any memory leaks, although looking into it, it seems to me that the saveCall by itself is redundant 😊 