### PR TITLE
fix: remove key_alias credentials only and prevent remove others

### DIFF
--- a/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
+++ b/android/src/main/java/com/epicshaggy/biometric/NativeBiometric.java
@@ -247,7 +247,8 @@ public class NativeBiometric extends Plugin {
             try {
                 getKeyStore().deleteEntry(KEY_ALIAS);
                 SharedPreferences.Editor editor = getContext().getSharedPreferences(NATIVE_BIOMETRIC_SHARED_PREFERENCES, Context.MODE_PRIVATE).edit();
-                editor.clear();
+                editor.remove(KEY_ALIAS + "-username");
+                editor.remove(KEY_ALIAS + "-password");
                 editor.apply();
                 call.resolve();
             } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {


### PR DESCRIPTION
We detected a problem when store multiple key alias on different servers and we want remove keys for specific server.

Result: all shared prefs alias was remove
Expected result: remove only a specific shared prefs for alias/server